### PR TITLE
feat(player): Implement CRUD endpoints for players

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,8 +7,8 @@
         "editor.formatOnSave": true,
         // Run additional "fix-all" and "organize imports" actions on save
         "editor.codeActionsOnSave": {
-            "source.fixAll": true,
-            "source.organizeImports": true
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit"
         }
     },
     // Enable basic type checking powered by your mypy installation

--- a/src/rankforge/api/player.py
+++ b/src/rankforge/api/player.py
@@ -1,0 +1,131 @@
+# src/rankforge/api/player.py
+
+"""API endpoints for managing players."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from rankforge.db.models import Player
+from rankforge.db.session import get_db
+from rankforge.schemas import player as player_schema
+
+# Create an APIRouter instance for players
+# - prefix="/players": All routes here will be prefixed with /players
+# - tags=["Players"]: Groups these endpoints under "Players" in the API docs
+router = APIRouter(prefix="/players", tags=["Players"])
+
+
+@router.post(
+    "/",
+    response_model=player_schema.PlayerRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_player(
+    player_in: player_schema.PlayerCreate, db: AsyncSession = Depends(get_db)
+) -> Player:
+    """
+    Create a new player.
+
+    - **name**: The unique name for the player.
+    """
+    # Create a new SQLAlchemy Player model instance
+    new_player = Player(**player_in.model_dump())
+
+    # Add, commit, and refresh to save to the database and get the new ID
+    db.add(new_player)
+    await db.commit()
+    await db.refresh(new_player)
+
+    # Return the newly created player object
+    return new_player
+
+
+@router.get("/", response_model=list[player_schema.PlayerRead])
+async def read_players(db: AsyncSession = Depends(get_db)) -> list[Player]:
+    """
+    Retrieve a list of all players.
+    """
+    # Create a query via a select statement
+    query = select(Player).order_by(Player.id)
+
+    # Execute the query.
+    result = await db.execute(query)
+
+    # Get all scalar results (the Player objects themselves) from the result.
+    players = result.scalars().all()
+
+    # Return list of players.
+    return list(players)
+
+
+@router.get("/{player_id}", response_model=player_schema.PlayerRead)
+async def read_player(player_id: int, db: AsyncSession = Depends(get_db)) -> Player:
+    """
+    Retrieve a single player by their ID.
+    """
+    # Fetch player by Primary Key
+    player = await db.get(Player, player_id)
+
+    # If not found, raise a standard 404 error
+    if not player:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Player with id {player_id} not found",
+        )
+
+    # Return the found player object
+    return player
+
+
+@router.put("/{player_id}", response_model=player_schema.PlayerRead)
+async def update_player(
+    player_id: int,
+    player_in: player_schema.PlayerUpdate,
+    db: AsyncSession = Depends(get_db),
+) -> Player:
+    """
+    Update a player's name.
+    """
+    # Fetch the existing player
+    player_to_update = await db.get(Player, player_id)
+    if not player_to_update:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Player with id {player_id} not found",
+        )
+
+    # Get the update data, excluding fields that were not sent
+    update_data = player_in.model_dump(exclude_unset=True)
+
+    # Update the model instance with the new data
+    for key, value in update_data.items():
+        setattr(player_to_update, key, value)
+
+    # Add, commit, and refresh
+    db.add(player_to_update)
+    await db.commit()
+    await db.refresh(player_to_update)
+
+    return player_to_update
+
+
+@router.delete("/{player_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_player(player_id: int, db: AsyncSession = Depends(get_db)) -> None:
+    """
+    Delete a player by their ID.
+    """
+    # Fetch the player to delete
+    player_to_delete = await db.get(Player, player_id)
+    if not player_to_delete:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Player with id {player_id} not found",
+        )
+
+    # Delete from the database
+    await db.delete(player_to_delete)
+    await db.commit()
+
+    # Return None for the 204 No Content response
+    return None

--- a/src/rankforge/main.py
+++ b/src/rankforge/main.py
@@ -5,12 +5,13 @@
 
 from fastapi import FastAPI
 
-from .api import game
+from .api import game, player
 
 app = FastAPI(title="RankForge API")
 
 # Include routers into the main application
 app.include_router(game.router)
+app.include_router(player.router)
 
 
 @app.get("/", tags=["Root"])

--- a/src/rankforge/schemas/player.py
+++ b/src/rankforge/schemas/player.py
@@ -1,0 +1,47 @@
+# src/rankforge/schemas/player.py
+
+"""Pydantic schemas for the Player resource."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+# ===============================================
+# Base Schema: Defines shared attributes for creation
+# ===============================================
+class PlayerBase(BaseModel):
+    """Shared properties for a player."""
+
+    name: str
+
+
+# ===============================================
+# Create Schema: Inherits the base properties
+# ===============================================
+class PlayerCreate(PlayerBase):
+    """Properties to receive via API on create."""
+
+    pass
+
+
+# ===============================================
+# Update Schema: Defines all fields as optional
+# ===============================================
+class PlayerUpdate(BaseModel):
+    """Properties to receive via API on update, all optional."""
+
+    name: str | None = None
+
+
+# ===============================================
+# Read Schema: Defines attributes for returning data
+# ===============================================
+class PlayerRead(PlayerBase):
+    """Properties to return to the client."""
+
+    id: int
+    created_at: datetime
+
+    # Enable ORM mode for this schema
+    model_config = ConfigDict(from_attributes=True)

--- a/tests/test_api_players.py
+++ b/tests/test_api_players.py
@@ -1,0 +1,115 @@
+# tests/test_api_players.py
+
+"""Tests for the Player API endpoints."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_create_player(async_client: AsyncClient):
+    """Test creating a new player via the POST /players/ endpoint."""
+    # 1. Define the data for the new player.
+    player_payload = {"name": "PlayerOne"}
+
+    # 2. Make the API call to create the player.
+    response = await async_client.post("/players/", json=player_payload)
+
+    # 3. Assert that the response is what we expect for a successful creation.
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["name"] == player_payload["name"]
+    assert "id" in data
+    assert isinstance(data["id"], int)
+
+    # The `created_at` field should also be present in the response
+    assert "created_at" in data
+
+
+@pytest.mark.asyncio
+async def test_read_player(async_client: AsyncClient):
+    """Test retrieving a single player by their ID."""
+    # 1. Create a player to ensure there's data to fetch.
+    player_payload = {"name": "PlayerToRead"}
+    create_response = await async_client.post("/players/", json=player_payload)
+    assert create_response.status_code == 201
+    player_id = create_response.json()["id"]
+
+    # 2. Try to fetch the player using their ID.
+    read_response = await async_client.get(f"/players/{player_id}")
+
+    # 3. Assert the request was successful and the data is correct.
+    assert read_response.status_code == 200
+    data = read_response.json()
+    assert data["id"] == player_id
+    assert data["name"] == player_payload["name"]
+
+
+@pytest.mark.asyncio
+async def test_list_players(async_client: AsyncClient):
+    """Test retrieving a list of all players."""
+    # 1. Create a couple of players to ensure the list is populated.
+    await async_client.post("/players/", json={"name": "Alice"})
+    await async_client.post("/players/", json={"name": "Bob"})
+
+    # 2. Make the call to the list endpoint.
+    response = await async_client.get("/players/")
+
+    # 3. Assert the request was successful and the data format is correct.
+    assert response.status_code == 200
+    data = response.json()
+
+    assert isinstance(data, list)
+    assert len(data) >= 2
+
+    # Verify that the names of the created players are in the response list.
+    response_names = {player["name"] for player in data}
+    assert "Alice" in response_names
+    assert "Bob" in response_names
+
+
+@pytest.mark.asyncio
+async def test_update_player(async_client: AsyncClient):
+    """Test updating an existing player's name."""
+    # 1. Create a player to update.
+    original_payload = {"name": "Charlie_Old"}
+    create_response = await async_client.post("/players/", json=original_payload)
+    assert create_response.status_code == 201
+    player_id = create_response.json()["id"]
+    original_name = create_response.json()["name"]
+
+    # 2. Define the update payload.
+    update_payload = {"name": "Charlie_New"}
+
+    # 3. Make the API call to update the player.
+    update_response = await async_client.put(
+        f"/players/{player_id}", json=update_payload
+    )
+
+    # 4. Assert that the update was successful.
+    assert update_response.status_code == 200
+    data = update_response.json()
+    assert data["id"] == player_id
+    assert data["name"] == update_payload["name"]
+    assert data["name"] != original_name
+
+
+@pytest.mark.asyncio
+async def test_delete_player(async_client: AsyncClient):
+    """Test deleting a player."""
+    # 1. Create a player to delete.
+    payload = {"name": "PlayerToDelete"}
+    create_response = await async_client.post("/players/", json=payload)
+    assert create_response.status_code == 201
+    player_id = create_response.json()["id"]
+
+    # 2. Make the API call to delete the player.
+    delete_response = await async_client.delete(f"/players/{player_id}")
+
+    # 3. Assert that the delete request was successful (204 No Content).
+    assert delete_response.status_code == 204
+
+    # 4. Verify that the player is gone by trying to fetch them again.
+    get_response = await async_client.get(f"/players/{player_id}")
+    assert get_response.status_code == 404


### PR DESCRIPTION
This commit introduces the complete set of CRUD (Create, Read, Update, Delete) operations for the `Player` resource.

A new API router is created in `src/rankforge/api/player.py` and integrated into the main FastAPI application. This provides a full-featured interface for managing players within the system.

The following endpoints are now available under the `/players` prefix:

- **`POST /`**: Creates a new player with a unique name.
- **`GET /`**: Retrieves a list of all existing players.
- **`GET /{player_id}`**: Fetches a single player by their ID, returning a 404 if not found.
- **`PUT /{player_id}`**: Updates the name of an existing player.
- **`DELETE /{player_id}`**: Deletes a player from the database, returning a 204 No Content on success.

These endpoints leverage `SQLAlchemy` for asynchronous database interactions and `Pydantic` schemas for robust request validation and response serialization.