### PR TITLE
feat(match): Implement CRUD endpoints for matches

### DIFF
--- a/src/rankforge/api/match.py
+++ b/src/rankforge/api/match.py
@@ -1,0 +1,134 @@
+# src/rankforge/api/match.py
+
+"""API endpoints for managing matches."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from rankforge.db.models import Match, MatchParticipant
+from rankforge.db.session import get_db
+from rankforge.schemas import match as match_schema
+
+# Create an APIRouter instance for matches
+router = APIRouter(prefix="/matches", tags=["Matches"])
+
+
+@router.get("/", response_model=list[match_schema.MatchRead])
+async def read_matches(db: AsyncSession = Depends(get_db)) -> list[Match]:
+    """
+    Retrieve a list of all matches, including participants and players.
+    """
+    # Create a query via a select statement
+    query = (
+        select(Match)
+        .order_by(Match.id)
+        .options(selectinload(Match.participants).selectinload(MatchParticipant.player))
+    )
+
+    # Execute the query.
+    result = await db.execute(query)
+
+    # Get all scalar results (the Match objects themselves) from the result.
+    matches = result.scalars().all()
+    return list(matches)
+
+
+@router.post(
+    "/", response_model=match_schema.MatchRead, status_code=status.HTTP_201_CREATED
+)
+async def create_match(
+    match_in: match_schema.MatchCreate, db: AsyncSession = Depends(get_db)
+) -> Match:
+    """
+    Create a new match and its participants.
+
+    This endpoint takes a nested payload to create a match and all its
+    associated participant records in a single transaction.
+    """
+    # 1. Create the parent Match object from the payload.
+    #    We exclude 'participants' because that's a list of schemas, not a direct field
+    match_data = match_in.model_dump(exclude={"participants"})
+    new_match = Match(**match_data)
+
+    # 2. Create MatchParticipant objects for each participant in the payload.
+    for participant_data in match_in.participants:
+        new_participant = MatchParticipant(**participant_data.model_dump())
+
+        # Associate this participant with the new match
+        new_match.participants.append(new_participant)
+
+    # 3. Add the new_match to the session.
+    #    SQLAlchemy's relationship configuration with `cascade="all, delete-orphan"`
+    #    means that adding the parent `Match` will also automatically add
+    #    all the `MatchParticipant` objects in its `participants` list.
+    db.add(new_match)
+    await db.commit()
+
+    # 4. Refresh the match to load all data from the DB, including relationships.
+    await db.refresh(
+        new_match,
+        attribute_names=["participants"],
+    )
+
+    # To load the nested player objects inside participants,
+    #   requery for the object with the relationships loaded.
+    result = await db.execute(
+        select(Match)
+        .where(Match.id == new_match.id)
+        .options(selectinload(Match.participants).selectinload(MatchParticipant.player))
+    )
+    created_match = result.scalar_one()
+
+    return created_match
+
+
+@router.get("/{match_id}", response_model=match_schema.MatchRead)
+async def read_match(match_id: int, db: AsyncSession = Depends(get_db)) -> Match:
+    """
+    Retrieve a single match by its ID, including its participants and their players.
+    """
+    # 1. Build a query to select the Match.
+    # 2. Use `options` and `selectinload` to create an efficient query that
+    #    "eager loads" the related participants and their nested player objects.
+    #    This prevents the "N+1 problem" by issuing just two extra queries
+    #    (one for all participants, one for all players) instead of one per participant.
+    query = (
+        select(Match)
+        .where(Match.id == match_id)
+        .options(selectinload(Match.participants).selectinload(MatchParticipant.player))
+    )
+
+    result = await db.execute(query)
+    match = result.scalar_one_or_none()
+
+    if not match:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Match with id {match_id} not found",
+        )
+
+    return match
+
+
+@router.delete("/{match_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_match(match_id: int, db: AsyncSession = Depends(get_db)) -> None:
+    """
+    Delete a match by its ID.
+    """
+    # Fetch the match to delete
+    match_to_delete = await db.get(Match, match_id)
+    if not match_to_delete:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Match with id {match_id} not found",
+        )
+
+    # Delete from the database. Thanks to `cascade="all, delete-orphan"` in our
+    # `models.py` relationship, SQLAlchemy will automatically delete all
+    # associated MatchParticipant records as well.
+    await db.delete(match_to_delete)
+    await db.commit()
+
+    return None

--- a/src/rankforge/main.py
+++ b/src/rankforge/main.py
@@ -5,13 +5,14 @@
 
 from fastapi import FastAPI
 
-from .api import game, player
+from .api import game, match, player
 
 app = FastAPI(title="RankForge API")
 
 # Include routers into the main application
 app.include_router(game.router)
 app.include_router(player.router)
+app.include_router(match.router)
 
 
 @app.get("/", tags=["Root"])

--- a/src/rankforge/schemas/match.py
+++ b/src/rankforge/schemas/match.py
@@ -1,0 +1,75 @@
+# src/rankforge/schemas/match.py
+
+"""Pydantic schemas for the Match resource."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .player import PlayerRead
+
+# ===============================================
+# == Match Participant Schemas
+# ===============================================
+
+
+class MatchParticipantBase(BaseModel):
+    """Shared properties for a match participant."""
+
+    player_id: int
+    team_id: int
+
+    # The `outcome` is a flexible JSON field to store results
+    outcome: dict
+
+
+class MatchParticipantCreate(MatchParticipantBase):
+    """Properties to receive when creating a participant within a match."""
+
+    pass
+
+
+class MatchParticipantRead(MatchParticipantBase):
+    """Properties to return to the client for a match participant."""
+
+    id: int
+
+    # Instead of just a player_id, return the full Player object.
+    player: PlayerRead
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ===============================================
+# == Match Schemas
+# ===============================================
+
+
+class MatchBase(BaseModel):
+    """Shared properties for a match."""
+
+    game_id: int
+
+    # The `match_metadata` is a flexible JSON field
+    match_metadata: dict = Field(default_factory=dict)
+
+
+class MatchCreate(MatchBase):
+    """
+    Properties to receive via API on create.
+    This is the main payload for submitting a new match.
+    """
+
+    participants: list[MatchParticipantCreate]
+
+
+class MatchRead(MatchBase):
+    """Properties to return to the client for a match."""
+
+    id: int
+    played_at: datetime
+
+    # The list of participants will use the "Read" schema to show full details.
+    participants: list[MatchParticipantRead]
+
+    model_config = ConfigDict(from_attributes=True)

--- a/tests/test_api_matches.py
+++ b/tests/test_api_matches.py
@@ -1,0 +1,214 @@
+# tests/test_api_matches.py
+"""Tests for the Match API endpoints."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_create_match(async_client: AsyncClient):
+    """Test creating a new match with participants."""
+    # 1. SETUP: Create a game and two players that will participate in the match.
+    game_res = await async_client.post(
+        "/games/", json={"name": "Geoguessr", "rating_strategy": "glicko2_team_binary"}
+    )
+    assert game_res.status_code == 201
+    game_id = game_res.json()["id"]
+
+    player1_res = await async_client.post("/players/", json={"name": "Alice"})
+    assert player1_res.status_code == 201
+    player1_id = player1_res.json()["id"]
+
+    player2_res = await async_client.post("/players/", json={"name": "Bob"})
+    assert player2_res.status_code == 201
+    player2_id = player2_res.json()["id"]
+
+    # 2. DEFINE PAYLOAD: Construct the nested payload for the new match.
+    match_payload = {
+        "game_id": game_id,
+        "match_metadata": {"map": "A Diverse World"},
+        "participants": [
+            {
+                "player_id": player1_id,
+                "team_id": 1,
+                "outcome": {"result": "win", "score": 24150},
+            },
+            {
+                "player_id": player2_id,
+                "team_id": 2,
+                "outcome": {"result": "loss", "score": 19870},
+            },
+        ],
+    }
+
+    # 3. EXECUTE: Make the API call to create the match.
+    response = await async_client.post("/matches/", json=match_payload)
+
+    # 4. ASSERT: Check for a successful creation and verify the nested data.
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["game_id"] == game_id
+    assert data["match_metadata"]["map"] == "A Diverse World"
+    assert "id" in data
+    assert "played_at" in data
+
+    # Assertions for the nested participants
+    assert len(data["participants"]) == 2
+    participant_pids = {p["player"]["id"] for p in data["participants"]}
+    assert player1_id in participant_pids
+    assert player2_id in participant_pids
+
+    # Check that the participants' outcome is correct
+    alice_data = next(
+        p for p in data["participants"] if p["player"]["id"] == player1_id
+    )
+    assert alice_data["outcome"]["result"] == "win"
+    assert alice_data["outcome"]["score"] == 24150
+
+    bob_data = next(p for p in data["participants"] if p["player"]["id"] == player2_id)
+    assert bob_data["outcome"]["result"] == "loss"
+    assert bob_data["outcome"]["score"] == 19870
+
+
+@pytest.mark.asyncio
+async def test_read_match(async_client: AsyncClient):
+    """Test retrieving a single match by its ID."""
+    # 1. SETUP: Create a game and players.
+    game_res = await async_client.post(
+        "/games/", json={"name": "TestGame", "rating_strategy": "test"}
+    )
+    game_id = game_res.json()["id"]
+
+    player1_res = await async_client.post("/players/", json={"name": "Player A"})
+    player1_id = player1_res.json()["id"]
+
+    player2_res = await async_client.post("/players/", json={"name": "Player B"})
+    player2_id = player2_res.json()["id"]
+
+    # 2. CREATE a match to fetch.
+    match_payload = {
+        "game_id": game_id,
+        "participants": [
+            {"player_id": player1_id, "team_id": 1, "outcome": {"result": "win"}},
+            {"player_id": player2_id, "team_id": 2, "outcome": {"result": "loss"}},
+        ],
+    }
+    create_response = await async_client.post("/matches/", json=match_payload)
+    assert create_response.status_code == 201
+    match_id = create_response.json()["id"]
+
+    # 3. EXECUTE: Try to fetch the match using its ID.
+    read_response = await async_client.get(f"/matches/{match_id}")
+
+    # 4. ASSERT the request was successful and the nested data is correct.
+    assert read_response.status_code == 200
+    data = read_response.json()
+
+    assert data["id"] == match_id
+    assert data["game_id"] == game_id
+    assert len(data["participants"]) == 2
+
+    # Sort participants by player ID for deterministic checks
+    sorted_participants = sorted(data["participants"], key=lambda p: p["player"]["id"])
+
+    # Assertions for the first participant (Player A)
+    p1_data = sorted_participants[0]
+    assert p1_data["player"]["id"] == player1_id
+    assert p1_data["player"]["name"] == "Player A"
+    assert p1_data["team_id"] == 1
+    assert p1_data["outcome"] == {"result": "win"}
+
+    # Assertions for the second participant (Player B)
+    p2_data = sorted_participants[1]
+    assert p2_data["player"]["id"] == player2_id
+    assert p2_data["player"]["name"] == "Player B"
+    assert p2_data["team_id"] == 2
+    assert p2_data["outcome"] == {"result": "loss"}
+
+
+@pytest.mark.asyncio
+async def test_list_matches(async_client: AsyncClient):
+    """Test retrieving a list of all matches."""
+    # 1. SETUP: Create a game and multiple players for different matches.
+    game_res = await async_client.post(
+        "/games/", json={"name": "ListTestGame", "rating_strategy": "test"}
+    )
+    game_id = game_res.json()["id"]
+
+    player_c_res = await async_client.post("/players/", json={"name": "Player C"})
+    player_c_id = player_c_res.json()["id"]
+
+    player_d_res = await async_client.post("/players/", json={"name": "Player D"})
+    player_d_id = player_d_res.json()["id"]
+
+    # 2. CREATE two distinct matches to ensure the list endpoint works.
+    match1_payload = {
+        "game_id": game_id,
+        "participants": [{"player_id": player_c_id, "team_id": 1, "outcome": {}}],
+    }
+    match1_res = await async_client.post("/matches/", json=match1_payload)
+    assert match1_res.status_code == 201
+    match1_id = match1_res.json()["id"]
+
+    match2_payload = {
+        "game_id": game_id,
+        "match_metadata": {"notes": "Second match"},
+        "participants": [{"player_id": player_d_id, "team_id": 1, "outcome": {}}],
+    }
+    match2_res = await async_client.post("/matches/", json=match2_payload)
+    assert match2_res.status_code == 201
+    match2_id = match2_res.json()["id"]
+
+    # 3. EXECUTE: Make the call to the list endpoint.
+    response = await async_client.get("/matches/")
+
+    # 4. ASSERT the request was successful and the data format is correct.
+    assert response.status_code == 200
+    matches_list = response.json()
+
+    assert isinstance(matches_list, list)
+    assert len(matches_list) >= 2
+
+    # Find our created matches in the response list
+    match1_data = next((m for m in matches_list if m["id"] == match1_id), None)
+    match2_data = next((m for m in matches_list if m["id"] == match2_id), None)
+
+    # Assert that both matches were found and their data is correct
+    assert match1_data is not None
+    assert match1_data["game_id"] == game_id
+    assert match1_data["participants"][0]["player"]["id"] == player_c_id
+
+    assert match2_data is not None
+    assert match2_data["match_metadata"] == {"notes": "Second match"}
+    assert match2_data["participants"][0]["player"]["id"] == player_d_id
+
+
+@pytest.mark.asyncio
+async def test_delete_match(async_client: AsyncClient):
+    """Test deleting a match."""
+    # 1. SETUP: Create a game, a player, and a match to delete.
+    game_res = await async_client.post(
+        "/games/", json={"name": "DeleteTestGame", "rating_strategy": "test"}
+    )
+    game_id = game_res.json()["id"]
+    player_res = await async_client.post("/players/", json={"name": "Player E"})
+    player_id = player_res.json()["id"]
+
+    match_payload = {
+        "game_id": game_id,
+        "participants": [{"player_id": player_id, "team_id": 1, "outcome": {}}],
+    }
+    create_response = await async_client.post("/matches/", json=match_payload)
+    assert create_response.status_code == 201
+    match_id = create_response.json()["id"]
+
+    # 2. EXECUTE: Make the API call to delete the match.
+    delete_response = await async_client.delete(f"/matches/{match_id}")
+
+    # 3. ASSERT that the delete request was successful.
+    assert delete_response.status_code == 204
+
+    # 4. VERIFY that the match is gone.
+    get_response = await async_client.get(f"/matches/{match_id}")
+    assert get_response.status_code == 404


### PR DESCRIPTION
This commit introduces the core API functionality for managing matches. It provides endpoints for creating, reading (both list and single), and deleting `Match` resources. An update endpoint is intentionally omitted for now.

The implementation includes:

- **API Router:**
  - A new router is created in `src/rankforge/api/match.py` and integrated into the main FastAPI application.

- **Endpoints:**
  - `POST /matches/`: Creates a new match along with its nested participants in a single transaction.
  - `GET /matches/`: Retrieves a list of all matches.
  - `GET /matches/{match_id}`: Fetches a single match by its ID.
  - `DELETE /matches/{match_id}`: Deletes a match and its associated participants.

- **Database Logic:**
  - Endpoints use efficient database querying with `selectinload` to prevent the N+1 problem when fetching matches with their related participants and players.
  - Deletion leverages the `cascade="all, delete-orphan"` model relationship to automatically remove child `MatchParticipant` records.

- **Testing:**
  - Comprehensive `pytest` tests have been added in `tests/test_api_matches.py` to validate the functionality of each new endpoint, ensuring data integrity and correct response formats for create, read, list, and delete operations.