### PR TITLE
feat(game-profile): Implement automatic profile creation and service …

### DIFF
--- a/src/rankforge/db/models.py
+++ b/src/rankforge/db/models.py
@@ -69,6 +69,9 @@ class Game(Base):
     )
     matches: Mapped[List["Match"]] = relationship(back_populates="game")
 
+    def __init__(self, **kw: Any):
+        super().__init__(**kw)
+
 
 class GameProfile(Base):
     """Stores a player's rating and stats for a specific game."""
@@ -91,6 +94,9 @@ class GameProfile(Base):
     game: Mapped["Game"] = relationship(back_populates="game_profiles")
 
     __table_args__ = (UniqueConstraint("player_id", "game_id", name="_player_game_uc"),)
+
+    def __init__(self, **kw: Any):
+        super().__init__(**kw)
 
 
 # ===============================================

--- a/src/rankforge/services/match_service.py
+++ b/src/rankforge/services/match_service.py
@@ -10,6 +10,40 @@ from rankforge.db import models
 from rankforge.rating import dummy_engine
 from rankforge.schemas import match as match_schema
 
+# A default rating structure for new players in a game.
+# NOTE: This will be eventually configured per-game
+DEFAULT_RATING_INFO = {"rating": 1500, "rd": 300, "vol": 0.06}
+
+
+async def get_or_create_game_profile(
+    db: AsyncSession, player_id: int, game_id: int
+) -> models.GameProfile:
+    """
+    Retrieves a player's game profile, creating it with default
+    values if it doesn't exist.
+    """
+    # Attempt to fetch an existing profile.
+    query = select(models.GameProfile).where(
+        models.GameProfile.player_id == player_id,
+        models.GameProfile.game_id == game_id,
+    )
+    result = await db.execute(query)
+    profile = result.scalar_one_or_none()
+
+    # If no profile exists, create a new one.
+    if profile is None:
+        profile = models.GameProfile(
+            player_id=player_id,
+            game_id=game_id,
+            rating_info=DEFAULT_RATING_INFO,
+            stats={},  # Start with empty stats
+        )
+        db.add(profile)
+        # NOTE: We don't commit here; the main function will handle the commit.
+        # We need to flush to get the profile object ready for use.
+        await db.flush()
+    return profile
+
 
 async def process_new_match(
     db: AsyncSession, match_in: match_schema.MatchCreate
@@ -22,14 +56,23 @@ async def process_new_match(
     2. Triggering the rating calculation process.
     3. Updating player profiles with new ratings and stats.
     """
-    # 1. Create the database models from the input schema
-    #    We exclude 'participants' because that's a list of schemas, not a direct field
+    # 1. Create the database models from the input schema.
+    #    We exclude 'participants' because that's a list of schemas, not a direct field.
     match_data = match_in.model_dump(exclude={"participants"})
     new_match = models.Match(**match_data)
 
-    # 2. Create MatchParticipant objects for each participant in the payload.
+    # 2. Ensure profiles exist and create participant records.
     for participant_data in match_in.participants:
-        new_participant = models.MatchParticipant(**participant_data.model_dump())
+        # For each participant, ensure their game profile exists.
+        profile = await get_or_create_game_profile(
+            db, player_id=participant_data.player_id, game_id=match_in.game_id
+        )
+
+        # Store the "before" rating for historical tracking
+        participant_with_history = participant_data.model_dump()
+        participant_with_history["rating_info_before"] = profile.rating_info
+
+        new_participant = models.MatchParticipant(**participant_with_history)
         new_match.participants.append(new_participant)
 
     # 3. Add the new match and its particpants to the session and commit.
@@ -37,10 +80,10 @@ async def process_new_match(
     await db.commit()
     await db.refresh(new_match)
 
-    # 4. Trigger the rating update process
+    # 4. Trigger the rating update process,
     await dummy_engine.update_ratings_for_match(db, new_match)
 
-    # 5. Re-query the match to eager load all relationships for the response
+    # 5. Re-query the match to eager load all relationships for the response.
     result = await db.execute(
         select(models.Match)
         .where(models.Match.id == new_match.id)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,85 @@
+# tests/test_services.py
+
+"""Unit tests for the service layer."""
+
+import pytest
+from rankforge.db.models import Game, GameProfile, Player
+from rankforge.schemas.match import MatchCreate, MatchParticipantCreate
+from rankforge.services import match_service
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_process_new_match_creates_game_profiles(db_session: AsyncSession):
+    """
+    Verify that processing a new match creates GameProfile entries for
+    participants who don't already have one for that game.
+    """
+    # 1. SETUP: Create a game and two players.
+    #    Crucially, these players have NO GameProfile for this game yet.
+    game = Game(name="Test Game", rating_strategy="test")
+    player1 = Player(name="FirstTimer")
+    player2 = Player(name="Veteran")  # Will also be a first-timer in this test
+    db_session.add_all([game, player1, player2])
+    await db_session.commit()
+
+    # Create a GameProfile for player2 in a *different* game to ensure
+    # our logic is specific.
+    other_game = Game(name="Other Game", rating_strategy="other")
+    db_session.add(other_game)
+    await db_session.commit()
+    # This existing profile should NOT be affected.
+    veteran_other_profile = GameProfile(
+        player_id=player2.id, game_id=other_game.id, rating_info={"rating": 1500}
+    )
+    db_session.add(veteran_other_profile)
+    await db_session.commit()
+
+    # 2. PREPARE INPUT: Create the Pydantic schema for the new match.
+    match_in = MatchCreate(
+        game_id=game.id,
+        participants=[
+            MatchParticipantCreate(
+                player_id=player1.id, team_id=1, outcome={"result": "win"}
+            ),
+            MatchParticipantCreate(
+                player_id=player2.id, team_id=2, outcome={"result": "loss"}
+            ),
+        ],
+    )
+
+    # 3. EXECUTE: Call the service function directly..
+    await match_service.process_new_match(db=db_session, match_in=match_in)
+
+    # 4. ASSERT: Check that the GameProfiles were created correctly.
+    #    Query for the GameProfile for player1 in the new game.
+    profile1_query = await db_session.execute(
+        select(GameProfile).where(
+            GameProfile.player_id == player1.id, GameProfile.game_id == game.id
+        )
+    )
+    created_profile1 = profile1_query.scalar_one_or_none()
+
+    # Assert that the profile was created.
+    assert created_profile1 is not None, "GameProfile for player1 was not created"
+
+    # NOTE: Will add assertions for  initial rating later.
+    # For now, just confirming it's not empty.
+    assert created_profile1.rating_info is not None
+
+    # Query for the GameProfile for player2 in the new game.
+    profile2_query = await db_session.execute(
+        select(GameProfile).where(
+            GameProfile.player_id == player2.id, GameProfile.game_id == game.id
+        )
+    )
+    created_profile2 = profile2_query.scalar_one_or_none()
+    assert created_profile2 is not None, "GameProfile for player2 was not created"
+
+    # Finally, ensure that the total number of profiles for player2 is now 2.
+    all_profiles_p2_query = await db_session.execute(
+        select(GameProfile).where(GameProfile.player_id == player2.id)
+    )
+    all_profiles_p2 = all_profiles_p2_query.scalars().all()
+    assert len(all_profiles_p2) == 2, "Incorrect total number of profiles for player2"


### PR DESCRIPTION
…tests

This commit introduces the core logic for managing player-specific game profiles and establishes the foundation for service-layer unit testing. This ensures that players automatically get a profile with default ratings when they play a game for the first time.

Key changes include:

- **Automatic GameProfile Creation:**
  - A new `get_or_create_game_profile` helper function has been added to `match_service.py`. When a new match is processed, this function automatically creates a `GameProfile` for any participant who doesn't already have one for that specific game.
  - The `process_new_match` service now captures the player's rating *before* the match (`rating_info_before`) and stores it on the `MatchParticipant` record for historical analysis.

- **Service Layer Unit Testing:**
  - A new test file, `tests/test_services.py`, has been created to unit test business logic directly, separate from the API endpoints.
  - The first test, `test_process_new_match_creates_game_profiles`, verifies that the service correctly creates new game profiles for first-time players in a game, without relying on HTTP requests. This improves test speed and isolation.