### PR TITLE
feat/team-rating: Generalize Glicko-2 for team-based outcomes

### DIFF
--- a/tests/test_rating_engine.py
+++ b/tests/test_rating_engine.py
@@ -1,0 +1,71 @@
+# tests/test_rating_engine.py
+
+"""Unit tests for the rating engine logic."""
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pytest
+from rankforge.db.models import Match
+from rankforge.rating.glicko2_engine import _calculate_player_scores
+
+
+# Use simple dataclasses to mock the necessary SQLAlchemy model attributes
+@dataclass
+class MockParticipant:
+    player_id: int
+    team_id: int
+    outcome: dict[str, Any]
+
+
+@dataclass
+class MockMatch:
+    participants: list[MockParticipant]
+
+
+def test_calculate_player_scores_for_ranked_teams():
+    """
+    Verify score normalization is based on the number of TEAMS, not players.
+    """
+    # 1. ARRANGE: An 8-player, 4-team match where teams are ranked 1st to 4th.
+    match = MockMatch(
+        participants=[
+            # Team 1 (Rank 4)
+            MockParticipant(player_id=1, team_id=1, outcome={"rank": 4}),
+            MockParticipant(player_id=2, team_id=1, outcome={"rank": 4}),
+            # Team 2 (Rank 3)
+            MockParticipant(player_id=3, team_id=2, outcome={"rank": 3}),
+            MockParticipant(player_id=4, team_id=2, outcome={"rank": 3}),
+            # Team 3 (Rank 2)
+            MockParticipant(player_id=5, team_id=3, outcome={"rank": 2}),
+            MockParticipant(player_id=6, team_id=3, outcome={"rank": 2}),
+            # Team 4 (Rank 1)
+            MockParticipant(player_id=7, team_id=4, outcome={"rank": 1}),
+            MockParticipant(player_id=8, team_id=4, outcome={"rank": 1}),
+        ]
+    )
+
+    # 2. ACT: Call the function under test.
+    scores = _calculate_player_scores(cast(Match, match))
+
+    # 3. ASSERT: The scores should be normalized based on 4 teams (3 opponents).
+    # Score = (NumOpponentTeams - (Rank - 1)) / NumOpponentTeams
+    # Rank 1: (3 - 0) / 3 = 1.0
+    # Rank 2: (3 - 1) / 3 = 0.666...
+    # Rank 3: (3 - 2) / 3 = 0.333...
+    # Rank 4: (3 - 3) / 3 = 0.0
+
+    # Assert scores for the 1st place team (players 7, 8)
+    assert scores[7] == pytest.approx(1.0)
+    assert scores[8] == pytest.approx(1.0)
+
+    # Assert scores for the 2nd place team (players 5, 6)
+    assert scores[5] == pytest.approx(2.0 / 3.0)
+    assert scores[6] == pytest.approx(2.0 / 3.0)
+
+    # Assert scores for the 3rd place team (players 3, 4)
+    assert scores[3] == pytest.approx(1.0 / 3.0)
+    assert scores[4] == pytest.approx(1.0 / 3.0)
+
+    # Assert scores for the 4th place team (players 1, 2)
+    assert scores[1] == pytest.approx(0.0)
+    assert scores[2] == pytest.approx(0.0)


### PR DESCRIPTION
This commit significantly refactors the Glicko-2 rating engine to correctly process team-based matches, making the system versatile enough to handle 1v1, N-player FFA, team vs. team, and ranked team FFA formats with a single, unified logic.

Previously, the engine's logic for ranked matches was flawed for team games. It incorrectly calculated a player's performance score by normalizing it against the total number of *players* instead of the number of competing *teams*. This led to incorrect rating adjustments, especially in ranked team scenarios where high-rated teams who performed as expected could still lose rating points.

The key changes are:

-   **Team-Aware Score Calculation:** A new `_calculate_player_scores` helper function has been introduced in `glicko2_engine.py`. This function is the core of the fix. It correctly determines the number of competing entities by counting the unique `team_id`s in a match. The performance score for ranked matches is now properly normalized against the number of opponent teams, not opponent players.

-   **Unified Outcome Handling:** The new helper function gracefully handles different outcome types. It prioritizes simple `win`/`loss` results for binary matches (like 1v1 or 2v2) and falls back to the new team-aware ranked logic for FFA-style games.

-   **Robust Test Coverage:**
    -   A new test file, `tests/test_rating_engine.py`, was created to unit test the `_calculate_player_scores` logic in isolation, confirming the score normalization is correct for ranked team games.
    -   New service-level tests were added to `tests/test_services.py` (`test_process_new_match_handles_2v2_team_game` and `test_process_new_match_handles_ranked_teams`) to validate the end-to-end correctness for both binary team and ranked team FFA matches.

This refactoring makes the rating system far more robust and capable of accurately modeling a wide variety of competitive formats without needing separate engines for each type.